### PR TITLE
Fix for gain setting and VTS register length

### DIFF
--- a/ov5647_modes.h
+++ b/ov5647_modes.h
@@ -882,7 +882,7 @@ struct sensor_def ov5647 = {
    .exposure_reg_num_bits = 20,
 
    .vts_reg =              0x380E,
-   .vts_reg_num_bits =     10,      // total vertical size [9:8] and [7:0] (ov5647 datasheet)
+   .vts_reg_num_bits =     16,      //  total vertical size [15:8] and [7:0] (ov5647 preliminary datasheet is inaccurate)
 
    .gain_reg =             0x350A,
    .gain_reg_num_bits =    10,

--- a/raspiraw.c
+++ b/raspiraw.c
@@ -1656,11 +1656,12 @@ void update_regs(const struct sensor_def *sensor, struct mode_def *mode, int hfl
 			int i, j=sensor->gain_reg_num_bits-1;
 			int num_regs = (sensor->gain_reg_num_bits+7)>>3;
 
-			for(i = 0; i<num_regs; i++, j-=8)
+			for(i = 0; i<num_regs; i++)
 			{
 				val = (gain >> (j&~7)) & 0xFF;
 				modReg(mode, sensor->gain_reg+i, 0, j&0x7, val, EQUAL);
 				vcos_log_error("Set gain %04X to %02X", sensor->gain_reg+i, val);
+				j -= ((j&0x7)+1);
 			}
 		}
 	}


### PR DESCRIPTION
Hi 6by9!

I'm submitting this pull request which fixes two issues that I've found in your code:

- First, the gain was not set correctly in the sensor. The values of registers 0x350A-0x350B were calculated correctly, but the 'endBit' was incorrectly passed to modReg();
- And second, I modified the length of the VTS register, as we discussed in [https://www.raspberrypi.org/forums/viewtopic.php?p=1331295#p1331295](url)

The gain fix should work for exposure and the other registers, but I tested it with the gain only.